### PR TITLE
use nix to bring in the project selection committee

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Build site
         run: |
-          nix-shell
+          nix-shell --run 'exit'
           cd src
           stack run -- clean
           stack run -- build

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -44,8 +44,14 @@ jobs:
           ./scripts/git-metadata
 
 
+      - uses: cachix/install-nix-action@v15
+        with:
+          nix_path: nixpkgs=channel:nixos-22.05
+
+
       - name: Build site
         run: |
+          nix-shell
           cd src
           stack run -- clean
           stack run -- build

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 src/project-selection-committee
+src/images/project-selection-committee

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+src/project-selection-committee

--- a/nixpkgs.json
+++ b/nixpkgs.json
@@ -1,0 +1,8 @@
+{
+  "owner": "nixos",
+  "repo": "nixpkgs",
+  "branch": "nixpkgs-22.05",
+  "rev": "d9794b04bffb468b886c553557489977ae5f4c65",
+  "sha256": "1l41dhs1cmwx7q7s38d9dr9zyijfm6bhmv41zr7rsg94yplbr0f1"
+}
+

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,7 @@
+let
+  spec = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
+  nixpkgs = fetchTarball {
+    url    = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";
+    sha256 = spec.sha256;
+  };
+in import nixpkgs

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,19 @@
+{ pkgs ? import ./nixpkgs.nix {} }:
+
+with pkgs;
+
+let org = builtins.fetchGit {
+            ref = "add-committee-members";
+            url = "https://github.com/FixPlanet/org";
+          };
+    path = "project-selection-committee";
+ in
+
+mkShell {
+  buildInputs = [ ];
+  shellHook = ''
+    rm -rf src/${path}
+    mkdir src/${path}
+    cp ${org.outPath}/${path}/* src/${path}
+  '';
+}

--- a/shell.nix
+++ b/shell.nix
@@ -2,9 +2,11 @@
 
 with pkgs;
 
-let org = builtins.fetchGit {
-            ref = "add-committee-members";
-            url = "https://github.com/FixPlanet/org";
+let org = pkgs.fetchgit {
+            url      = "https://github.com/FixPlanet/org";
+            rev      = "d62c8d9c321f5a2dffa5cac13b384300cf009fcc";
+            sha256   = "sha256-WDUrGrR4DwRSajjSgYPWtdZA9joZUd8hHkWh8/gr0Lc=";
+            fetchLFS = true;
           };
     path = "project-selection-committee";
  in
@@ -12,8 +14,14 @@ let org = builtins.fetchGit {
 mkShell {
   buildInputs = [ ];
   shellHook = ''
+    # Markdown files
     rm -rf src/${path}
     mkdir src/${path}
-    cp ${org.outPath}/${path}/* src/${path}
+    cp ${org.outPath}/${path}/*.md src/${path}
+
+    # Images
+    rm -rf src/images/${path}
+    mkdir src/images/${path}
+    cp ${org.outPath}/${path}/*.{png,jpg} src/images/${path}
   '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -4,8 +4,8 @@ with pkgs;
 
 let org = pkgs.fetchgit {
             url      = "https://github.com/FixPlanet/org";
-            rev      = "d62c8d9c321f5a2dffa5cac13b384300cf009fcc";
-            sha256   = "sha256-WDUrGrR4DwRSajjSgYPWtdZA9joZUd8hHkWh8/gr0Lc=";
+            rev      = "c4b1e9d3f2ad08984fb1031d012ed142ba975a47";
+            sha256   = "sha256-jsHRBLF3UyUa/ftPvgJ9ajme5iJkQd26vvWVqz0W0fU=";
             fetchLFS = true;
           };
     path = "project-selection-committee";

--- a/src/committee.md
+++ b/src/committee.md
@@ -1,0 +1,16 @@
+---
+title: Project Selection Committee
+---
+
+# Project selection committee <a name="project-selection-committee"></a>
+
+Projects will be reviewed by this group of people.
+
+<div class="committee-members">
+$for(members)$
+<div class="member">
+  <h2> $name$ </h2>
+   $body$
+</div>
+$endfor$
+</div>

--- a/src/committee.md
+++ b/src/committee.md
@@ -9,8 +9,13 @@ Projects will be reviewed by this group of people.
 <div class="committee-members">
 $for(members)$
 <div class="member">
-  <h2> $name$ </h2>
+  <div class="image">
+   <img src="/images/project-selection-committee/$imageName$" />
+  </div>
+  <div class="member-content">
+  <h2> <a href="$link$">$name$</a></h2>
    $body$
+  </div>
 </div>
 $endfor$
 </div>

--- a/src/css/Style.hs
+++ b/src/css/Style.hs
@@ -32,7 +32,32 @@ main = putCss $
   >> mainHeader
   >> links
   >> mainContent
+  >> members
   >> footerStuff
+
+
+members :: Css
+members = do
+  div # ".committee-members" ? do
+    display       flex
+    flexDirection row
+    flexWrap      (FlexWrap "wrap")
+
+    div # ".member" ? do
+      "box-shadow" -: "14px 14px 36px -3px rgba(0,0,0,0.1);"
+      allBorderRadius (px 10)
+      allMargin       (px 20)
+      allPadding      (px 20)
+      display         flex
+      flexDirection   row
+      width           (px 600)
+
+      div # ".image" ? do
+        marginRight (px 15)
+
+      img ? do
+        allBorderRadius (px 150)
+        width           (px 150)
 
 
 footerStuff :: Css

--- a/src/css/Style.hs
+++ b/src/css/Style.hs
@@ -46,7 +46,7 @@ members = do
     div # ".member" ? do
       "box-shadow" -: "14px 14px 36px -3px rgba(0,0,0,0.1);"
       allBorderRadius (px 10)
-      allMargin       (px 20)
+      allMargin       (px 10)
       allPadding      (px 20)
       display         flex
       flexDirection   row

--- a/src/templates/default.html
+++ b/src/templates/default.html
@@ -46,8 +46,8 @@
         <ul class="menu">
           <li><a alt="Home" title="Home" href="/">Home</a></li>
           <!-- <li><a alt="Blog" title="Blog" href="/">Blog</a></li> -->
-          <li><a alt="Governance" title="Governance" href="https://github.com/FixPlanet/org#governance">Governance <img src="/images/out.png" height=12 /></a></li>
           <li><a alt="Project selection committee" title="Project selection committee" href="/committee.html">Project selection committee</a></li>
+          <li><a alt="Governance" title="Governance" href="https://github.com/FixPlanet/org#governance">Governance <img src="/images/out.png" height=12 /></a></li>
         </ul>
       </div>
     </nav>
@@ -76,8 +76,8 @@
           <!-- TODO: Link to TypeForm -->
           <li> <a href="">Apply for a grant</a> </li>
           <!-- <li> <a href="/blog.html">Blog</a> </li> -->
-          <li><a alt="Governance" title="Governance" href="https://github.com/FixPlanet/org#governance">Governance <img src="/images/out.png" height=10 /></a></li>
           <li><a alt="Project selection committee" title="Project selection committee" href="/committee.html">Project selection committee</a></li>
+          <li><a alt="Governance" title="Governance" href="https://github.com/FixPlanet/org#governance">Governance <img src="/images/out.png" height=10 /></a></li>
           <li><a alt="FixPlanet on GitHub" title="FixPlanet on GitHub" href="https://github.com/FixPlanet">github/FixPlanet <img src="/images/out.png" height=10 /></a></li>
         </ul>
       </div>

--- a/src/templates/default.html
+++ b/src/templates/default.html
@@ -47,7 +47,7 @@
           <li><a alt="Home" title="Home" href="/">Home</a></li>
           <!-- <li><a alt="Blog" title="Blog" href="/">Blog</a></li> -->
           <li><a alt="Governance" title="Governance" href="https://github.com/FixPlanet/org#governance">Governance <img src="/images/out.png" height=12 /></a></li>
-          <li><a alt="Program committee" title="Program committee" href="https://github.com/FixPlanet/org/blob/main/committee.md">Program committee <img src="/images/out.png" height=12 /></a></li>
+          <li><a alt="Project selection committee" title="Project selection committee" href="/committee.html">Project selection committee</a></li>
         </ul>
       </div>
     </nav>
@@ -77,7 +77,7 @@
           <li> <a href="">Apply for a grant</a> </li>
           <!-- <li> <a href="/blog.html">Blog</a> </li> -->
           <li><a alt="Governance" title="Governance" href="https://github.com/FixPlanet/org#governance">Governance <img src="/images/out.png" height=10 /></a></li>
-          <li><a alt="Program committee" title="Program committee" href="https://github.com/FixPlanet/org/blob/main/committee.md">Program committee <img src="/images/out.png" height=10 /></a></li>
+          <li><a alt="Project selection committee" title="Project selection committee" href="/committee.html">Project selection committee</a></li>
           <li><a alt="FixPlanet on GitHub" title="FixPlanet on GitHub" href="https://github.com/FixPlanet">github/FixPlanet <img src="/images/out.png" height=10 /></a></li>
         </ul>
       </div>


### PR DESCRIPTION
wip 

fixes #15 

we can manage the project selection committee in the main org repo, and bring them in using this "one trick nix users don't want you to know about"

maybe it's a nice idea?

see also - https://github.com/FixPlanet/org/pull/25

-- edit:

probably worth noting i've done this in a terrible way. there's probably a more "nix-y" way to do it; so if anyone knows, please do fix/advise.

Todo:

- [x] The nix-shell thing needs to run as part of the CI build