### PR TITLE
trustee tag

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -4,8 +4,8 @@ with pkgs;
 
 let org = pkgs.fetchgit {
             url      = "https://github.com/FixPlanet/org";
-            rev      = "2d420929f6934c03f331f07ce72bfcab688a085d";
-            sha256   = "sha256-WsWQtmWktUrxZQVMMmQ/jEaR854xPh1muWRCSFEBm7g=";
+            rev      = "4507755ee4ce43e279995b21b384aef338ee81f3";
+            sha256   = "sha256-cQzjlrSzu8m8PsbOe/+YVRqc1y0SR4NlfJZ7KKqqyqU=";
             fetchLFS = true;
           };
     path = "project-selection-committee";

--- a/src/committee.md
+++ b/src/committee.md
@@ -10,8 +10,7 @@ Projects will be reviewed by this group of people.
 $for(members)$
 <div class="member">
   <div class="image">
-   <img src="/images/project-selection-committee/$imageName$" />
-   $if(cofounder)$ <span class="co-founder">co-founder</span> $endif$
+   <img src="/images/project-selection-committee/$imageName$" /> $if(cofounder)$<span class="co-founder">co-founder</span>$endif$ $if(trustee)$<span class="trustee">trustee</span>$endif$
   </div>
   <div class="member-content">
   <h2> <a href="$link$">$name$</a>

--- a/src/css/Style.hs
+++ b/src/css/Style.hs
@@ -64,13 +64,16 @@ members = do
         width           (px 150)
         marginBottom    (px 10)
 
-      span # ".co-founder" ? do
+      (span # ".co-founder" <> span # ".trustee") ? do
         allBorderRadius (px 5)
         allPadding      (px 4)
-        background      lavender
         fontSize        (px 11)
+        allMargin       (px 5)
         monoFont
         textDecoration  none
+
+      span # ".co-founder" ? background lavender
+      span # ".trustee"    ? background wheat
 
 
 footerStuff :: Css


### PR DESCRIPTION
there's no reason the existing co-founders need to always be the trustees; and it is proving useful to be able to refer to the trustees publically; hence this tag.